### PR TITLE
Parallelize and handle deleted accounts

### DIFF
--- a/LabeledByAI.Services/GitHub/GitHubProject.cs
+++ b/LabeledByAI.Services/GitHub/GitHubProject.cs
@@ -25,7 +25,7 @@ public class GitHubProject(GitHub github, string owner, int number)
     {
         var items = await GetAllItemsAsync(includeClosed);
 
-        foreach (var item in items)
+        await Parallel.ForEachAsync(items, async (item, ct) =>
         {
             if (item.Content is GitHubIssue issue)
             {
@@ -35,7 +35,7 @@ public class GitHubProject(GitHub github, string owner, int number)
 
             // TODO: PRs
             // TODO: draft issues
-        }
+        });
 
         return items;
     }
@@ -117,7 +117,7 @@ public class GitHubProject(GitHub github, string owner, int number)
                             i.Repository.Name,
                             i.Number,
                             i.State == IssueState.Open,
-                            i.Author.Login,
+                            i.Author == null ? "ghost" : i.Author.Login,
                             i.Title,
                             i.Body,
                             i.Comments(null, null, null, null, null)
@@ -132,8 +132,8 @@ public class GitHubProject(GitHub github, string owner, int number)
                                 .ToList()
                         ))
                     )
-                    // TODO: PRs
-                    // TODO: draft issues
+                // TODO: PRs
+                // TODO: draft issues
                 ))
                 .ToList()
             )

--- a/LabeledByAI/LabeledByAI.http
+++ b/LabeledByAI/LabeledByAI.http
@@ -113,3 +113,17 @@ X-GitHub-Token: {{GitHubToken}}
 }
 
 ###
+
+POST {{HostAddress}}/api/engagement-score
+Content-Type: application/json
+X-GitHub-Token: {{GitHubToken}}
+
+{
+  "version": 1,
+  "project": {
+    "owner": "mono",
+    "number": 1
+  }
+}
+
+###


### PR DESCRIPTION
* Loading all the comments in series takes too long, parallel is both faster and more efficient
* Sometimes accounts are deleted, and this means the author of an issue or comment may be null

This pull request includes several changes to improve the performance and robustness of the GitHub project and repository services. The most important changes include switching to parallel processing for fetching items and handling cases where authors are null.

Performance improvements:

* [`LabeledByAI.Services/GitHub/GitHubProject.cs`](diffhunk://#diff-dc2102b945d2e53433efa71f6e361adecb08086a3b3201a86c1efe87813a3980L28-R28): Switched to using `Parallel.ForEachAsync` for processing items in `GetAllItemsDetailedAsync` to improve performance. [[1]](diffhunk://#diff-dc2102b945d2e53433efa71f6e361adecb08086a3b3201a86c1efe87813a3980L28-R28) [[2]](diffhunk://#diff-dc2102b945d2e53433efa71f6e361adecb08086a3b3201a86c1efe87813a3980L38-R38)
* [`LabeledByAI.Services/GitHub/GitHubRepository.cs`](diffhunk://#diff-bec27289440906010a20425568ea7d71265d7c13ed29a0bb26cdb587166a4737L63-R70): Switched to using `Parallel.ForEachAsync` for processing issues in `GetAllIssuesDetailedAsync` to improve performance.

Robustness improvements:

* [`LabeledByAI.Services/GitHub/GitHubProject.cs`](diffhunk://#diff-dc2102b945d2e53433efa71f6e361adecb08086a3b3201a86c1efe87813a3980L120-R120): Added a check to handle cases where the author is null by assigning "ghost" as the author in `FetchAllItemsAsync`.
* [`LabeledByAI.Services/GitHub/GitHubRepository.cs`](diffhunk://#diff-bec27289440906010a20425568ea7d71265d7c13ed29a0bb26cdb587166a4737L95-R96): Added a check to handle cases where the author is null by assigning "ghost" as the author in `FetchIssueCommentsAsync`.
* [`LabeledByAI.Services/GitHub/GitHubRepository.cs`](diffhunk://#diff-bec27289440906010a20425568ea7d71265d7c13ed29a0bb26cdb587166a4737L38-R38): Modified `GetIssueDetailedAsync` to only fetch comments if `TotalComments` is greater than zero.

Additionally, a new API endpoint was added for engagement scores:

* [`LabeledByAI/LabeledByAI.http`](diffhunk://#diff-e3a097e8165288268a788e726510dca096dc45667f7390f21d443b0d830172c7R116-R129): Added a new POST request to the API for submitting engagement scores.