### PR TITLE
Move the GitHub token to the concrete connection

### DIFF
--- a/LabeledByAI.Services/GitHub/IGitHubConnection.cs
+++ b/LabeledByAI.Services/GitHub/IGitHubConnection.cs
@@ -2,8 +2,6 @@
 
 public interface IGitHubConnection
 {
-    void SetToken(string githubToken);
-
     Task<IReadOnlyList<GitHubLabel>> FetchLabelsAsync(string owner, string repo);
 
     Task<GitHubIssue> FetchIssueAsync(string owner, string repo, int number);

--- a/LabeledByAI.Services/Services/Engagement/EngagementService.cs
+++ b/LabeledByAI.Services/Services/Engagement/EngagementService.cs
@@ -5,7 +5,7 @@ namespace LabeledByAI.Services;
 
 public class EngagementService(IGitHubConnection githubConnection, ILogger<EngagementService> logger)
 {
-    public async Task<EngagementResponse> CalculateScoresAsync(EngagementRequest request, string githubToken)
+    public async Task<EngagementResponse> CalculateScoresAsync(EngagementRequest request)
     {
         // TODO:
         // - download the github issue and all the comments and reactions
@@ -19,7 +19,6 @@ public class EngagementService(IGitHubConnection githubConnection, ILogger<Engag
         // - calc all issues in a project
         // - calc all issues in a project in the last [7/10/30] days
 
-        githubConnection.SetToken(githubToken);
         var github = new GitHub(githubConnection);
 
         if (request.Issue is { } reqIssue)

--- a/LabeledByAI.Services/Services/LabelSelector/LabelSelectorService.cs
+++ b/LabeledByAI.Services/Services/LabelSelector/LabelSelectorService.cs
@@ -7,13 +7,12 @@ namespace LabeledByAI.Services;
 
 public class LabelSelectorService(IGitHubConnection githubConnection, IChatClient chatClient, ILogger<LabelSelectorService> logger)
 {
-    public async Task<LabelSelectorResponse> SelectLabelAsync(LabelSelectorRequest request, string githubToken)
+    public async Task<LabelSelectorResponse> SelectLabelAsync(LabelSelectorRequest request)
     {
         var reqIssue = request.Issue;
         var reqLabels = request.Labels;
 
         // get github repository
-        githubConnection.SetToken(githubToken);
         var github = new GitHub(githubConnection);
         var repo = github.GetRepository(reqIssue.Owner, reqIssue.Repo);
 

--- a/LabeledByAI/Functions/EngagementScoreFunction.cs
+++ b/LabeledByAI/Functions/EngagementScoreFunction.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace LabeledByAI;
 
-public class EngagementScoreFunction(EngagementService service, ILogger<EngagementScoreFunction> logger)
+public class EngagementScoreFunction(GitHubRemoteConnection connection, EngagementService service, ILogger<EngagementScoreFunction> logger)
     : BaseFunction<EngagementRequest>(logger)
 {
     [Function("engagement-score")]
@@ -14,7 +14,8 @@ public class EngagementScoreFunction(EngagementService service, ILogger<Engageme
 
     protected override async Task<IResult> OnRun(HttpRequest request, EngagementRequest parsedBody)
     {
-        var response = await service.CalculateScoresAsync(parsedBody, request.GetGithubToken());
+        connection.SetToken(request.GetGithubToken());
+        var response = await service.CalculateScoresAsync(parsedBody);
         return TypedResults.Ok(response);
     }
 }

--- a/LabeledByAI/Functions/LabelSelectorFunction.cs
+++ b/LabeledByAI/Functions/LabelSelectorFunction.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace LabeledByAI;
 
-public class LabelSelectorFunction(LabelSelectorService service, ILogger<LabelSelectorFunction> logger)
+public class LabelSelectorFunction(GitHubRemoteConnection connection, LabelSelectorService service, ILogger<LabelSelectorFunction> logger)
     : BaseFunction<LabelSelectorRequest>(logger)
 {
     [Function("label")]
@@ -14,7 +14,8 @@ public class LabelSelectorFunction(LabelSelectorService service, ILogger<LabelSe
 
     protected override async Task<IResult> OnRun(HttpRequest request, LabelSelectorRequest parsedBody)
     {
-        var response = await service.SelectLabelAsync(parsedBody, request.GetGithubToken());
+        connection.SetToken(request.GetGithubToken());
+        var response = await service.SelectLabelAsync(parsedBody);
         return TypedResults.Ok(response);
     }
 }

--- a/LabeledByAI/Program.cs
+++ b/LabeledByAI/Program.cs
@@ -11,7 +11,9 @@ builder.Services.AddProblemDetails();
 
 builder.Services.AddScoped<LabelSelectorService>();
 builder.Services.AddScoped<EngagementService>();
-builder.Services.AddScoped<IGitHubConnection, GitHubRemoteConnection>();
+builder.Services.AddScoped<GitHubRemoteConnection>();
+builder.Services.AddScoped<IGitHubConnection>(static provider =>
+    provider.GetRequiredService<GitHubRemoteConnection>());
 
 builder.AddServiceDefaults();
 


### PR DESCRIPTION
No need for it to be on the interface - and this can be seen by the fact that the unit tests don't need it.